### PR TITLE
Wrap stream in a promise to allow async

### DIFF
--- a/lib/gspark.js
+++ b/lib/gspark.js
@@ -1,14 +1,14 @@
-var fs = require('fs');
-var path = require('path');
-var archiver = require('archiver');
-var AWS = require('aws-sdk');
-var _ = require('lodash');
-var minimist = require('minimist');
+let fs = require('fs');
+let path = require('path');
+let archiver = require('archiver');
+let AWS = require('aws-sdk');
+let _ = require('lodash');
+let minimist = require('minimist');
 
-var argv = minimist(process.argv.slice(2));
+let argv = minimist(process.argv.slice(2));
 
 if (argv._[0] === 'init') {
-  var template = {
+  let template = {
     aws: {
       accessKeyId: '',
       secretAccessKey: '',
@@ -34,8 +34,8 @@ function usage() {
 if (!argv.c) {
   usage();
 }
-var config = JSON.parse(fs.readFileSync(argv.c));
-var files = [];
+let config = JSON.parse(fs.readFileSync(argv.c));
+let files = [];
 
 if (argv.f) {
   files = argv.f.split(',')
@@ -51,20 +51,11 @@ if (argv.f) {
 }
 
 AWS.config.update(config.aws);
-var s3Stream = require('s3-upload-stream')(new AWS.S3());
+let s3Stream = require('s3-upload-stream')(new AWS.S3());
 
-var archive = archiver('zip');
-var i, file, filePath, name, stream;
-for (i = 0;i < files.length;i++) {
-  file = files[i];
-  name = path.basename(file);
-  stream = fs.createReadStream(file);
-  archive.append(stream, {
-    name: name
-  });
-}
+let archive = archiver('zip');
 
-var archiveKey = config.key;
+let archiveKey = config.key;
 if (!archiveKey) {
   archiveKey = String(Date.now()) + '.zip';
   if (argv.p) {
@@ -72,36 +63,73 @@ if (!archiveKey) {
   }
 }
 
-var upload = s3Stream.upload({
+let upload = s3Stream.upload({
   Bucket: config.bucket,
   Key: archiveKey,
   ServerSideEncryption: 'AES256',
   ACL: 'private'
 });
 
-upload.on('error', function(err) {
-  console.log(err);
-  console.log(err.stack);
-  process.exit();
-});
+// Use a promise that resolves when the stream emits an end event
+const getStreamEndPromise = (stream) => {
+  return new Promise((resolve, reject) => {
+    stream.on('end', resolve);
+    stream.on('error', reject);
+  });
+}
 
-upload.on('uploaded', function(result) {
-  console.log('Upload completed!');
-  if (config.erase) {
-    console.log('Erasing files...');
-    for (i in files) {
-      fs.unlinkSync(files[i]);
-    }
-    console.log('Files erased!');
+const archiveAndUpload = async () => {
+
+  const streamPromises = [];
+
+  let i, file, filePath, name, stream;
+  for (i = 0; i < files.length; i++) {
+    file = files[i];
+    name = path.basename(file);
+    stream = fs.createReadStream(file);
+
+    streamPromises.push(getStreamEndPromise(stream));
+
+    archive.append(stream, {
+      name: name
+    });
   }
-  process.exit();
-});
+    
+  upload.on('error', function(err) {
+    console.log(err);
+    console.log(err.stack);
+    process.exit();
+  });
+  
+  upload.on('uploaded', function(result) {
+    console.log('Upload completed!');
+    if (config.erase) {
+      console.log('Erasing files...');
+      for (i in files) {
+        fs.unlinkSync(files[i]);
+      }
+      console.log('Files erased!');
+    }
+    process.exit();
+  });
+  
+  archive.on('error', function(err) {
+    console.log(err);
+    console.log(err.stack);
+    process.exit();
+  });
 
-archive.on('error', function(err) {
-  console.log(err);
-  console.log(err.stack);
-  process.exit();
-});
+  await Promise.all(streamPromises)
+  
+  archive.pipe(upload);
+  archive.finalize();
+}
 
-archive.pipe(upload);
-archive.finalize();
+archiveAndUpload()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
This PR should fix the 'unexpected end of file' error when downloading backups. I believe the issue is caused by the archive being piped and finalized _before_ the stream is finished.